### PR TITLE
fix romfs not found

### DIFF
--- a/NightFall/Makefile
+++ b/NightFall/Makefile
@@ -48,7 +48,7 @@ DATA				:=	data
 INCLUDES			:=	include
 ROMFS				:=	resources
 BOREALIS_PATH		:=	borealis
-BOREALIS_RESOURCES	:=	romfs:/
+BOREALIS_RESOURCES	:=	romfs:\x2F
 
 #---------------------------------------------------------------------------------
 # options for code generation


### PR DESCRIPTION
some times in windows the / caracter is bad taked by the compiler and use other stuff